### PR TITLE
Support OpenAI-compatible providers (DeepSeek, Ollama, etc.)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ WORKDIR /app
 RUN rm -rf /app/frontend
 RUN bun install
 
+# Patch @ai-sdk/openai: force systemMessageMode to "system" for non-OpenAI providers
+# The SDK defaults to "developer" role for unknown model IDs, which DeepSeek doesn't support
+RUN sed -i 's/const systemMessageMode = isReasoningModel ? "developer" : "system"/const systemMessageMode = "system"/' \
+    /app/node_modules/@ai-sdk/openai/dist/index.mjs
+
 # Final stage for app image
 FROM base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,6 @@ WORKDIR /app
 RUN rm -rf /app/frontend
 RUN bun install
 
-# Patch @ai-sdk/openai: force systemMessageMode to "system" for non-OpenAI providers
-# The SDK defaults to "developer" role for unknown model IDs, which DeepSeek doesn't support
-RUN sed -i 's/const systemMessageMode = isReasoningModel ? "developer" : "system"/const systemMessageMode = "system"/' \
-    /app/node_modules/@ai-sdk/openai/dist/index.mjs
-
 # Final stage for app image
 FROM base
 

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -1,8 +1,8 @@
 import { createGroq } from "@ai-sdk/groq";
 import { createOpenAI } from "@ai-sdk/openai";
 
-type AIClient = ReturnType<typeof createGroq> | ReturnType<typeof createOpenAI>;
-let aiClient: AIClient;
+type AIProvider = ReturnType<typeof createGroq> | ReturnType<typeof createOpenAI>;
+let aiProvider: AIProvider;
 
 const EMBEDDING_MODEL = "text-embedding-3-small";
 
@@ -12,24 +12,28 @@ const openai_base_url: string =
 const ai_provider: string = process.env.AI_PROVIDER || "groq";
 
 if (ai_provider == "groq") {
-  aiClient = createGroq({
+  aiProvider = createGroq({
     apiKey: process.env.GROQ_API_KEY,
   });
 } else {
-  aiClient = createOpenAI({
-    compatibility: "compatible",
+  aiProvider = createOpenAI({
     apiKey: process.env.OPENAI_API_KEY,
     baseURL: openai_base_url,
   });
 }
 
+// Wrap the provider so calling aiClient(modelId) uses the chat endpoint
+// instead of the responses endpoint (which non-OpenAI providers don't support)
+const aiClient = (modelId: string) => {
+  if (ai_provider === "openai" && !process.env.OPENAI_BASE_URL) {
+    return aiProvider(modelId);
+  }
+  return aiProvider.chat(modelId);
+};
+
 const embeddingClient = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 }).embedding(EMBEDDING_MODEL);
-
-if (!aiClient) {
-  throw new Error("Failed to initialize AI client");
-}
 
 export { aiClient, embeddingClient };
 export { ai_provider };

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -17,6 +17,7 @@ if (ai_provider == "groq") {
   });
 } else {
   aiClient = createOpenAI({
+    compatibility: "compatible",
     apiKey: process.env.OPENAI_API_KEY,
     baseURL: openai_base_url,
   });

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -1,5 +1,7 @@
 import { createGroq } from "@ai-sdk/groq";
 import { createOpenAI } from "@ai-sdk/openai";
+import { wrapLanguageModel } from "ai";
+import type { LanguageModelV1Prompt } from "@ai-sdk/provider";
 
 type AIProvider = ReturnType<typeof createGroq> | ReturnType<typeof createOpenAI>;
 let aiProvider: AIProvider;
@@ -10,6 +12,7 @@ const EMBEDDING_MODEL = "text-embedding-3-small";
 const openai_base_url: string =
   process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
 const ai_provider: string = process.env.AI_PROVIDER || "groq";
+const useCustomBaseUrl = !!process.env.OPENAI_BASE_URL;
 
 if (ai_provider == "groq") {
   aiProvider = createGroq({
@@ -22,13 +25,29 @@ if (ai_provider == "groq") {
   });
 }
 
-// Wrap the provider so calling aiClient(modelId) uses the chat endpoint
-// instead of the responses endpoint (which non-OpenAI providers don't support)
+// For non-OpenAI providers (e.g. DeepSeek), force chat completions endpoint
+// and rewrite "developer" role to "system" (only OpenAI supports "developer")
 const aiClient = (modelId: string) => {
-  if (ai_provider === "openai" && !process.env.OPENAI_BASE_URL) {
+  if (ai_provider !== "openai" || !useCustomBaseUrl) {
     return aiProvider(modelId);
   }
-  return aiProvider.chat(modelId);
+  const baseModel = aiProvider.chat(modelId);
+  return wrapLanguageModel({
+    model: baseModel,
+    middleware: {
+      transformParams: async ({ params }) => {
+        return {
+          ...params,
+          prompt: params.prompt.map((msg) => {
+            if (msg.role === ("developer" as any)) {
+              return { ...msg, role: "system" as const };
+            }
+            return msg;
+          }) as LanguageModelV1Prompt,
+        };
+      },
+    },
+  });
 };
 
 const embeddingClient = createOpenAI({

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -1,7 +1,5 @@
 import { createGroq } from "@ai-sdk/groq";
 import { createOpenAI } from "@ai-sdk/openai";
-import { wrapLanguageModel } from "ai";
-import type { LanguageModelV1Prompt } from "@ai-sdk/provider";
 
 type AIProvider = ReturnType<typeof createGroq> | ReturnType<typeof createOpenAI>;
 let aiProvider: AIProvider;
@@ -12,47 +10,50 @@ const EMBEDDING_MODEL = "text-embedding-3-small";
 const openai_base_url: string =
   process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
 const ai_provider: string = process.env.AI_PROVIDER || "groq";
-const useCustomBaseUrl = !!process.env.OPENAI_BASE_URL;
+const isCustomBaseUrl = !!process.env.OPENAI_BASE_URL;
 
 if (ai_provider == "groq") {
   aiProvider = createGroq({
     apiKey: process.env.GROQ_API_KEY,
   });
 } else {
+  // When using a custom base URL (e.g. DeepSeek, Ollama, Together), wrap fetch
+  // to rewrite the "developer" role to "system", since only OpenAI supports it.
+  const customFetch: typeof fetch = async (url, init) => {
+    if (isCustomBaseUrl && init?.body && typeof init.body === "string") {
+      try {
+        const body = JSON.parse(init.body);
+        if (Array.isArray(body.messages)) {
+          body.messages = body.messages.map((m: any) =>
+            m.role === "developer" ? { ...m, role: "system" } : m
+          );
+          init = { ...init, body: JSON.stringify(body) };
+        }
+      } catch {}
+    }
+    return fetch(url, init);
+  };
+
   aiProvider = createOpenAI({
     apiKey: process.env.OPENAI_API_KEY,
     baseURL: openai_base_url,
+    fetch: isCustomBaseUrl ? customFetch : undefined,
   });
 }
 
-// For non-OpenAI providers (e.g. DeepSeek), force chat completions endpoint
-// and rewrite "developer" role to "system" (only OpenAI supports "developer")
-const aiClient = (modelId: string) => {
-  if (ai_provider !== "openai" || !useCustomBaseUrl) {
-    return aiProvider(modelId);
-  }
-  const baseModel = aiProvider.chat(modelId);
-  return wrapLanguageModel({
-    model: baseModel,
-    middleware: {
-      transformParams: async ({ params }) => {
-        return {
-          ...params,
-          prompt: params.prompt.map((msg) => {
-            if (msg.role === ("developer" as any)) {
-              return { ...msg, role: "system" as const };
-            }
-            return msg;
-          }) as LanguageModelV1Prompt,
-        };
-      },
-    },
-  });
-};
+// Use .chat() to target the Chat Completions API (/v1/chat/completions).
+// The default provider() targets the Responses API (/v1/responses) which
+// is only supported by OpenAI. Chat Completions works with all providers
+// and covers all of Hydra's AI features (summarization, filtering, queries).
+const aiClient = (modelId: string) => aiProvider.chat(modelId);
 
 const embeddingClient = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 }).embedding(EMBEDDING_MODEL);
+
+if (!aiProvider) {
+  throw new Error("Failed to initialize AI client");
+}
 
 export { aiClient, embeddingClient };
 export { ai_provider };


### PR DESCRIPTION
## Summary

The Vercel AI SDK v5 introduced two behaviors that break OpenAI-compatible providers like DeepSeek, Ollama, Together, and others:

1. **Default model factory uses the Responses API** (`/v1/responses`) — only OpenAI supports this endpoint. All other providers only implement Chat Completions (`/v1/chat/completions`).
2. **Non-GPT model IDs get the `developer` message role** — the SDK treats unknown model IDs as reasoning models and sends `developer` instead of `system`. Only OpenAI accepts the `developer` role.

This PR fixes both issues in `utils/models.ts`:

- **Always use `.chat()`** to target Chat Completions. Hydra only uses `generateText` for summarization, filtering, and queries — none of which need Responses API features. Chat Completions works with every provider.
- **Custom `fetch` wrapper** (only when `OPENAI_BASE_URL` is set) that rewrites `developer` → `system` in the request body before it hits the provider.

No new env vars or breaking changes — existing OpenAI and Groq setups work exactly as before. Self-hosters with a custom `OPENAI_BASE_URL` now get automatic compatibility.

### Example `.env` for DeepSeek

```
AI_PROVIDER=openai
OPENAI_API_KEY=sk-...
OPENAI_BASE_URL=https://api.deepseek.com
OPENAI_SUMMARY_MODEL=deepseek-chat
OPENAI_QUERY_MODEL=deepseek-chat
OPENAI_FILTER_MODEL=deepseek-chat
```

## Test plan

- [x] Tested with DeepSeek (`deepseek-chat`) — summarize comments, filter posts, ask questions all working
- [x] Verified no changes to default Groq behavior (`AI_PROVIDER=groq`)
- [x] Verified native OpenAI still works when no `OPENAI_BASE_URL` is set